### PR TITLE
Refactor: Use derived jitter for error analysis and plotting

### DIFF
--- a/light_curve_fitting/jwstdata.py
+++ b/light_curve_fitting/jwstdata.py
@@ -32,9 +32,7 @@ class SpectroData:
 def normalize_flux(flux, flux_err, norm_range):
     """Normalize flux arrays by median of first 50 points."""
     flux = np.array(flux)
-    flux_err = np.array(flux_err)
     flux_norm = flux * 1.0
-    flux_err_norm = flux_err * 1.0
     
     for i in range(flux.shape[0]):
         if norm_range is None or np.sum(norm_range) == 0:
@@ -43,7 +41,7 @@ def normalize_flux(flux, flux_err, norm_range):
         else:
             norm = np.nanmedian(flux[i, norm_range])
         flux_norm[i, :] /= norm
-        flux_err_norm[i, :] /= norm
+    flux_err_norm = np.ones_like(flux_norm)
         
     return flux_norm, flux_err_norm
 
@@ -176,7 +174,7 @@ def process_spectroscopy_data(instrument, input_dir, output_dir, planet_str, cfg
     wavelengths_err = np.array(wavelengths_err)
     time = np.array(time)
     flux_unbinned = np.array(flux_unbinned)  # Shape: (n_time, n_wavelength)
-    flux_err_unbinned = np.array(flux_err_unbinned) 
+    flux_err_unbinned = np.ones_like(flux_unbinned)
     
     # Remove NaN columns
     nanmask = np.all(np.isnan(flux_unbinned), axis=0)
@@ -215,7 +213,7 @@ def process_spectroscopy_data(instrument, input_dir, output_dir, planet_str, cfg
     
     wlc = np.nansum(flux_unbinned, axis=1)
     wl_flux = wlc/np.nanmedian(wlc[oot_mask], axis=0)
-    wl_flux_err = np.nanmedian(np.abs(0.5*(wl_flux[0:-2] + wl_flux[2:]) - wl_flux[1:-1]))
+    wl_flux_err = 1.0
 
     return SpectroData(
         time=jnp.array(time),

--- a/light_curve_fitting/plotting_lineartrend.py
+++ b/light_curve_fitting/plotting_lineartrend.py
@@ -5,7 +5,7 @@ from jaxoplanet.light_curves import limb_dark_light_curve
 from jaxoplanet.orbits.transit import TransitOrbit
 import jax.numpy as jnp
 
-def plot_map_fits(t, indiv_y, yerr, wavelengths, map_params, transit_params, filename, ncols=3, detrend_type='linear'):
+def plot_map_fits(t, indiv_y, jitter, wavelengths, map_params, transit_params, filename, ncols=3, detrend_type='linear'):
     """
     Plot the MAP fits for each wavelength. The transit parameters (period, duration, 
     impact parameter, and transit time) are provided via transit_params, and detrend_offset 
@@ -51,7 +51,7 @@ def plot_map_fits(t, indiv_y, yerr, wavelengths, map_params, transit_params, fil
             raise ValueError(f"Unknown detrend_type: {detrend_type}")
             
         model = model + trend      
-        ax.errorbar(t, indiv_y[i], yerr=yerr[i], fmt='.', alpha=0.3,
+        ax.errorbar(t, indiv_y[i], yerr=jitter[i], fmt='.', alpha=0.3,
                     color=colors[i], label='Data', ms=1, zorder=2)
         ax.plot(t, model, c='k', alpha=1, lw=2.8,
                 label='MAP Model', zorder=3)
@@ -65,7 +65,7 @@ def plot_map_fits(t, indiv_y, yerr, wavelengths, map_params, transit_params, fil
     return fig
 
 
-def plot_map_residuals(t, indiv_y, yerr, wavelengths, map_params, transit_params, filename, ncols=3, detrend_type='linear'):
+def plot_map_residuals(t, indiv_y, jitter, wavelengths, map_params, transit_params, filename, ncols=3, detrend_type='linear'):
     """
     Plot the residuals for each wavelength using the transit parameters provided via transit_params.
     """
@@ -110,7 +110,7 @@ def plot_map_residuals(t, indiv_y, yerr, wavelengths, map_params, transit_params
         model = model + trend
         residuals = indiv_y[i] - model
         
-        ax.errorbar(t, residuals, yerr=yerr[i], fmt='.', alpha=0.3,
+        ax.errorbar(t, residuals, yerr=jitter[i], fmt='.', alpha=0.3,
                     ms=1, color=colors[i])
         ax.axhline(y=0, color='k', alpha=1, lw=2.8, zorder=3)
         ax.text(0.05, 0.95, f'λ = {wavelengths[i]:.3f} μm',


### PR DESCRIPTION
This commit refactors the analysis pipeline to use a model-derived jitter term for error analysis and plotting, instead of relying on input flux errors.

The key changes are:
- `jwstdata.py` is modified to replace all input flux errors with placeholder arrays of ones. This ensures that the fitting process is not influenced by potentially unreliable input errors.
- `plotting_lineartrend.py` is updated to accept a `jitter` parameter in its plotting functions, which is then used to render error bars.
- `fit_jwst.py` is updated to pass the median of the jitter posterior from the MCMC samples to the plotting functions for the white light, low-resolution, and high-resolution analyses.
- The RMS vs. Wavelength plots have been enhanced to show a comparison between the measured out-of-transit data scatter and the model-inferred jitter.